### PR TITLE
Delete exported sticker set and UI improvements

### DIFF
--- a/app/src/main/java/cc/microblock/TGStickerProvider/ui/activity/MainActivity.kt
+++ b/app/src/main/java/cc/microblock/TGStickerProvider/ui/activity/MainActivity.kt
@@ -152,32 +152,38 @@ class RecyclerAdapterStickerList(private val act: MainActivity) :
             });
         }
 
-        fun ProgressDialog.dialogUpdate() {
-            act.runOnUiThread {
-                setCancelable(true)
-                setMessage("正在更新列表")
-            }
-            act.updateStickerList()
-            act.runOnUiThread { dismiss() }
-        }
-
-        val dialogDelExported = {
+        fun deleteDialog(title: String, message: String, icon: Int, action: () -> Unit) {
             AlertDialog.Builder(act)
-                .setTitle("删除导出缓存 ${s.name}")
-                .setMessage("你将删除已缓存的表情包集 ${s.name}，这不会影响已同步的表情包，是否继续？")
-                .setIcon(android.R.drawable.ic_menu_delete)
+                .setTitle(title)
+                .setMessage(message)
+                .setIcon(icon)
                 .setPositiveButton("删除") { _, _ ->
                     val pd = ProgressDialog(act)
                     pd.setMessage("正在删除")
                     pd.show()
                     pd.setCancelable(false)
                     Thread {
-                        File("$stickerDataPath/${s.hash}").delete()
-                        File("$destDataPath/tgSync_${s.id}").deleteRecursively()
-                        pd.dialogUpdate()
+                        action()
+                        act.runOnUiThread {
+                            pd.setCancelable(true)
+                            pd.setMessage("正在更新列表")
+                        }
+                        act.updateStickerList()
+                        act.runOnUiThread { pd.dismiss() }
                     }.start()
                 }
                 .setNegativeButton("算了", null).show()
+        }
+
+        val dialogDelExported = {
+            deleteDialog(
+                title = "删除导出缓存 ${s.name}",
+                message = "你将删除已缓存的表情包集 ${s.name}，这不会影响已同步的表情包，是否继续？",
+                icon = android.R.drawable.ic_menu_delete,
+            ) {
+                File("$stickerDataPath/${s.hash}").delete()
+                File("$destDataPath/tgSync_${s.id}").deleteRecursively()
+            }
         }
 
         holder.rmBtn.setOnClickListener {
@@ -185,22 +191,16 @@ class RecyclerAdapterStickerList(private val act: MainActivity) :
             if (holder.unsupported.isVisible) {
                 dialogDelExported()
             } else {
-                AlertDialog.Builder(act).setTitle("删除已同步的表情包集 ${s.name}")
-                    .setMessage("你将删除已同步的表情包集 ${s.name}，这将会删除 ${s.syncedState.all} 个表情包文件，是否继续？")
-                    .setIcon(android.R.drawable.ic_dialog_alert).setPositiveButton("删除") { _, _ ->
-                        val pd = ProgressDialog(act)
-                        pd.setMessage("正在删除")
-                        pd.show()
-                        pd.setCancelable(false)
-                        Thread {
-                            // val remoteFolder = "${destDataPath}tgSync_${s.id}"
-                            // File(remoteFolder).deleteRecursively()
-                            File("$realDataPath/tgSync_${s.id}").deleteRecursively()
-                            pd.dialogUpdate()
-                        }.start()
-                    }.setNegativeButton("算了", null).show()
+                deleteDialog(
+                    title = "删除已同步的表情包集 ${s.name}",
+                    message = "你将删除已同步的表情包集 ${s.name}，这将会删除 ${s.syncedState.all} 个表情包文件，是否继续？",
+                    icon = android.R.drawable.ic_dialog_alert,
+                ) {
+                    File("$realDataPath/tgSync_${s.id}").deleteRecursively()
+                }
             }
         }
+
         holder.rmBtn.setOnLongClickListener {
             dialogDelExported()
             true

--- a/app/src/main/java/cc/microblock/TGStickerProvider/ui/activity/MainActivity.kt
+++ b/app/src/main/java/cc/microblock/TGStickerProvider/ui/activity/MainActivity.kt
@@ -20,8 +20,8 @@ import android.widget.Button
 import android.widget.TextView
 import android.widget.Toast
 import android.widget.VideoView
-import androidx.annotation.RequiresApi
 import androidx.cardview.widget.CardView
+import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
 import androidx.lifecycle.MutableLiveData
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -129,7 +129,7 @@ class RecyclerAdapterStickerList(private val act: MainActivity) :
                 holder.imageView.visibility = View.GONE
                 holder.videoCard.visibility = View.GONE
                 holder.videoView.stopPlayback()
-                holder.rmBtn.visibility = View.GONE
+                holder.rmBtn.visibility = View.VISIBLE
                 holder.syncBtn.visibility = View.GONE
                 holder.unsupported.visibility = View.VISIBLE
                 holder.unsupported.text = "不支持的表情包"
@@ -152,27 +152,55 @@ class RecyclerAdapterStickerList(private val act: MainActivity) :
             });
         }
 
-        holder.rmBtn.setOnClickListener {
-            // dialog confirm
+        fun ProgressDialog.dialogUpdate() {
+            act.runOnUiThread { setMessage("正在更新列表") }
+            act.updateStickerList()
+            act.runOnUiThread { dismiss() }
+        }
+
+        val dialogDelExported = {
             AlertDialog.Builder(act)
-                .setTitle("删除已同步的表情包集 ${s.name}")
-                .setMessage("你将删除已同步的表情包集 ${s.name}，这将会删除 ${s.syncedState.all} 个表情包文件，是否继续？")
-                .setIcon(android.R.drawable.ic_dialog_alert)
+                .setTitle("删除导出缓存 ${s.name}")
+                .setMessage("你将删除已缓存的表情包集 ${s.name}，这不会影响已同步的表情包，是否继续？")
+                .setIcon(android.R.drawable.ic_menu_delete)
                 .setPositiveButton("删除") { _, _ ->
                     val pd = ProgressDialog(act)
                     pd.setMessage("正在删除")
                     pd.show()
                     pd.setCancelable(false)
                     Thread {
-                        // val remoteFolder = "${destDataPath}tgSync_${s.id}"
-                        // File(remoteFolder).deleteRecursively()
-                        File("$realDataPath/tgSync_${s.id}").deleteRecursively()
-                        act.runOnUiThread { pd.setMessage("正在更新列表") }
-                        act.updateStickerList()
-                        act.runOnUiThread { pd.dismiss() }
+                        File("$stickerDataPath/${s.hash}").delete()
+                        File("$destDataPath/tgSync_${s.id}").deleteRecursively()
+                        pd.dialogUpdate()
                     }.start()
                 }
                 .setNegativeButton("算了", null).show()
+        }
+
+        holder.rmBtn.setOnClickListener {
+            // dialog confirm
+            if (holder.unsupported.isVisible) {
+                dialogDelExported()
+            } else {
+                AlertDialog.Builder(act).setTitle("删除已同步的表情包集 ${s.name}")
+                    .setMessage("你将删除已同步的表情包集 ${s.name}，这将会删除 ${s.syncedState.all} 个表情包文件，是否继续？")
+                    .setIcon(android.R.drawable.ic_dialog_alert).setPositiveButton("删除") { _, _ ->
+                        val pd = ProgressDialog(act)
+                        pd.setMessage("正在删除")
+                        pd.show()
+                        pd.setCancelable(false)
+                        Thread {
+                            // val remoteFolder = "${destDataPath}tgSync_${s.id}"
+                            // File(remoteFolder).deleteRecursively()
+                            File("$realDataPath/tgSync_${s.id}").deleteRecursively()
+                            pd.dialogUpdate()
+                        }.start()
+                    }.setNegativeButton("算了", null).show()
+            }
+        }
+        holder.rmBtn.setOnLongClickListener {
+            dialogDelExported()
+            true
         }
         //        holder.hash.text = stickerList[position].hash
     }

--- a/app/src/main/java/cc/microblock/TGStickerProvider/ui/activity/MainActivity.kt
+++ b/app/src/main/java/cc/microblock/TGStickerProvider/ui/activity/MainActivity.kt
@@ -13,7 +13,6 @@ import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.Settings
-import android.util.Log.e
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -27,15 +26,8 @@ import androidx.core.widget.doOnTextChanged
 import androidx.lifecycle.MutableLiveData
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import cc.microblock.TGStickerProvider.BuildConfig
-import cc.microblock.TGStickerProvider.R
+import cc.microblock.TGStickerProvider.*
 import cc.microblock.TGStickerProvider.databinding.ActivityMainBinding
-import cc.microblock.TGStickerProvider.destDataPath
-import cc.microblock.TGStickerProvider.exposedPath
-import cc.microblock.TGStickerProvider.nomediaPath2
-import cc.microblock.TGStickerProvider.realDataPath
-import cc.microblock.TGStickerProvider.stickerDataPath
-import cc.microblock.TGStickerProvider.tgspDataPath
 import cc.microblock.TGStickerProvider.ui.activity.base.BaseActivity
 import com.arthenica.ffmpegkit.FFmpegKit
 import com.bumptech.glide.Glide

--- a/app/src/main/java/cc/microblock/TGStickerProvider/ui/activity/MainActivity.kt
+++ b/app/src/main/java/cc/microblock/TGStickerProvider/ui/activity/MainActivity.kt
@@ -516,7 +516,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
             File("$exposedPath/ignore.txt").run {
                 if (exists())
                     readLines().filterNot { it.isEmpty() || it.startsWith("#") }
-                        .map { it.substringBefore(' ').substringBefore('#') }
+                        .map { it.substringBefore('#').trim() }
                         .toSet()
                 else {
                     writeText(

--- a/app/src/main/java/cc/microblock/TGStickerProvider/ui/activity/MainActivity.kt
+++ b/app/src/main/java/cc/microblock/TGStickerProvider/ui/activity/MainActivity.kt
@@ -13,6 +13,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.Settings
+import android.util.Log.e
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -522,20 +523,21 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
         val ignoreIds = try {
             File("$exposedPath/ignore.txt").run {
                 if (exists())
-                    readLines().filterNot { it.startsWith("#") }
+                    readLines().filterNot { it.isEmpty() || it.startsWith("#") }
                         .map { it.substringBefore(' ').substringBefore('#') }
+                        .toSet()
                 else {
                     writeText(
                         """# write the ignored sticker IDs here
                             |# separate with line breaks
                         """.trimMargin()
                     )
-                    emptyList()
+                    emptySet()
                 }
             }
         } catch (e: Exception) {
             YLog.error("Error while reading ignore.txt", e)
-            emptyList()
+            emptySet()
         }
         YLog.info("ignoreIds: [${ignoreIds.joinToString { "`$it`" }}]")
 

--- a/app/src/main/java/cc/microblock/TGStickerProvider/ui/activity/MainActivity.kt
+++ b/app/src/main/java/cc/microblock/TGStickerProvider/ui/activity/MainActivity.kt
@@ -350,7 +350,23 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
     }
 
     var filter = ""
+    var requiresSyncOnly = false
     var useHighQualityGif = false
+
+    fun onFilterChanged(list: List<StickerInfo>? = stickerList.value) {
+        if (list == null) return
+        (binding.stickerManageView.adapter as RecyclerAdapterStickerList).stickerList = list.filter {
+            if (requiresSyncOnly
+                && it.syncedState.all >= it.remoteState.all
+                && it.syncedState.highQuality >= it.remoteState.highQuality
+            ) return@filter false
+
+            it.name.contains(filter, ignoreCase = true) || it.id.contains(filter, ignoreCase = true)
+                    || it.type.contains(filter, ignoreCase = true)
+        }
+        binding.stickerManageView.adapter?.notifyDataSetChanged()
+    }
+
     @SuppressLint("NotifyDataSetChanged")
     override fun onCreate() {
         refreshModuleStatus()
@@ -359,6 +375,10 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
         binding.button2.setOnClickListener {
             binding.tips.visibility = View.GONE
             binding.manage.visibility = View.VISIBLE
+        }
+        binding.requiresSyncOnlySwitch.setOnCheckedChangeListener { _, isChecked ->
+            requiresSyncOnly = isChecked
+            onFilterChanged()
         }
         binding.gifQualitySwitch.setOnCheckedChangeListener { _, isChecked ->
             useHighQualityGif = isChecked
@@ -457,12 +477,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
 
         binding.searchBar.doOnTextChanged() { text, _, _, _ ->
             filter = text.toString()
-            (binding.stickerManageView.adapter as RecyclerAdapterStickerList).stickerList =
-                stickerList.value?.filter {
-                    it.name.contains(filter, ignoreCase = true) || it.id.contains(filter, ignoreCase = true)
-                            || it.type.contains(filter, ignoreCase = true)
-                } ?: listOf()
-            binding.stickerManageView.adapter?.notifyDataSetChanged()
+            onFilterChanged()
         }
 
         binding.stickerManageView.layoutManager = LinearLayoutManager(this)
@@ -486,13 +501,9 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
 //            YLog.error("Error while setting max fling velocity", e)
 //        }
 
-        stickerList.observe(this) {
+        stickerList.observe(this) { list ->
             runOnUiThread {
-                (binding.stickerManageView.adapter as RecyclerAdapterStickerList).stickerList = it.filter {
-                    it.name.contains(filter, ignoreCase = true) || it.id.contains(filter, ignoreCase = true)
-                            || it.type.contains(filter, ignoreCase = true)
-                }
-                binding.stickerManageView.adapter?.notifyDataSetChanged()
+                onFilterChanged(list)
             }
         }
     }

--- a/app/src/main/java/cc/microblock/TGStickerProvider/ui/activity/MainActivity.kt
+++ b/app/src/main/java/cc/microblock/TGStickerProvider/ui/activity/MainActivity.kt
@@ -153,7 +153,10 @@ class RecyclerAdapterStickerList(private val act: MainActivity) :
         }
 
         fun ProgressDialog.dialogUpdate() {
-            act.runOnUiThread { setMessage("正在更新列表") }
+            act.runOnUiThread {
+                setCancelable(true)
+                setMessage("正在更新列表")
+            }
             act.updateStickerList()
             act.runOnUiThread { dismiss() }
         }

--- a/app/src/main/java/cc/microblock/TGStickerProvider/ui/activity/MainActivity.kt
+++ b/app/src/main/java/cc/microblock/TGStickerProvider/ui/activity/MainActivity.kt
@@ -521,7 +521,9 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
 
         val ignoreIds = try {
             File("$exposedPath/ignore.txt").run {
-                if (exists()) readLines().filterNot { it.startsWith("#") }
+                if (exists())
+                    readLines().filterNot { it.startsWith("#") }
+                        .map { it.substringBefore(' ').substringBefore('#') }
                 else {
                     writeText(
                         """# write the ignored sticker IDs here

--- a/app/src/main/java/cc/microblock/TGStickerProvider/ui/activity/MainActivity.kt
+++ b/app/src/main/java/cc/microblock/TGStickerProvider/ui/activity/MainActivity.kt
@@ -181,8 +181,8 @@ class RecyclerAdapterStickerList(private val act: MainActivity) :
                 message = "你将删除已缓存的表情包集 ${s.name}，这不会影响已同步的表情包，是否继续？",
                 icon = android.R.drawable.ic_menu_delete,
             ) {
-                File("$stickerDataPath/${s.hash}").delete()
                 File("$destDataPath/tgSync_${s.id}").deleteRecursively()
+                File("$stickerDataPath/${s.hash}").delete()
             }
         }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -203,7 +203,14 @@
 
         </LinearLayout>
 
-        <Switch
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/requiresSyncOnlySwitch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="只显示待同步表情包" />
+
+        <androidx.appcompat.widget.SwitchCompat
             android:id="@+id/gifQualitySwitch"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -203,18 +203,16 @@
 
         </LinearLayout>
 
-        <androidx.appcompat.widget.SwitchCompat
+        <com.google.android.material.switchmaterial.SwitchMaterial
             android:id="@+id/requiresSyncOnlySwitch"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
+            android:layout_height="32dp"
             android:text="只显示待同步表情包" />
 
-        <androidx.appcompat.widget.SwitchCompat
+        <com.google.android.material.switchmaterial.SwitchMaterial
             android:id="@+id/gifQualitySwitch"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
+            android:layout_height="32dp"
             android:text="高清 Gif（慢）" />
 
         <TextView

--- a/app/src/main/res/layout/item_sticker.xml
+++ b/app/src/main/res/layout/item_sticker.xml
@@ -17,7 +17,7 @@
 
         <TextView
             android:id="@+id/sticker_name"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:maxHeight="16sp"
             android:text=""
@@ -26,7 +26,7 @@
 
         <TextView
             android:id="@+id/sticker_id"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:maxHeight="18sp"
             android:text=""
@@ -212,7 +212,8 @@
         android:id="@+id/unsupported"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="24dp"
+        android:layout_marginBottom="16dp"
+        android:layout_marginRight="4dp"
         android:text="不支持的格式"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/item_sticker.xml
+++ b/app/src/main/res/layout/item_sticker.xml
@@ -19,7 +19,6 @@
             android:id="@+id/sticker_name"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:maxHeight="16sp"
             android:text=""
             android:textColor="@color/colorPrimaryAccent"
             android:textSize="12sp"
@@ -29,7 +28,6 @@
             android:id="@+id/sticker_id"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:maxHeight="18sp"
             android:text=""
             android:textSize="16sp"
             android:textIsSelectable="true" />
@@ -210,6 +208,7 @@
         android:layout_marginTop="5dp"
         app:cardCornerRadius="8dp"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
         <VideoView

--- a/app/src/main/res/layout/item_sticker.xml
+++ b/app/src/main/res/layout/item_sticker.xml
@@ -212,10 +212,10 @@
         android:id="@+id/unsupported"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
+        android:gravity="center_vertical"
         android:layout_marginRight="4dp"
         android:text="不支持的格式"
-        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/rmBtn" />
 

--- a/app/src/main/res/layout/item_sticker.xml
+++ b/app/src/main/res/layout/item_sticker.xml
@@ -22,7 +22,8 @@
             android:maxHeight="16sp"
             android:text=""
             android:textColor="@color/colorPrimaryAccent"
-            android:textSize="12sp" />
+            android:textSize="12sp"
+            android:textIsSelectable="true" />
 
         <TextView
             android:id="@+id/sticker_id"
@@ -30,7 +31,8 @@
             android:layout_height="wrap_content"
             android:maxHeight="18sp"
             android:text=""
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            android:textIsSelectable="true" />
 
         <LinearLayout
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_sticker.xml
+++ b/app/src/main/res/layout/item_sticker.xml
@@ -143,35 +143,45 @@
 
     </LinearLayout>
 
-    <Button
-        android:id="@+id/syncBtn"
-        android:layout_width="83dp"
-        android:layout_height="42dp"
-        android:layout_marginEnd="40dp"
-        android:layout_marginBottom="12dp"
-        android:layout_weight="1"
-        android:backgroundTint="#757575"
-        android:insetLeft="2dp"
-        android:insetRight="2dp"
-        android:text="@string/sync"
-        android:textColor="#fff"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
-
-    <TextView
-        android:id="@+id/rmBtn"
-        android:layout_width="35dp"
-        android:layout_height="34dp"
-        android:layout_marginTop="19dp"
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
         android:layout_marginEnd="4dp"
-        android:background="@drawable/rounded_corner"
-        android:clickable="true"
-        android:text="@string/remove"
-        android:textAlignment="center"
-        android:textColor="#fff"
-        android:textSize="24sp"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+    >
+        <TextView
+            android:id="@+id/unsupported"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginRight="4dp"
+            android:text="不支持的格式" />
+
+        <Button
+            android:id="@+id/syncBtn"
+            android:layout_width="83dp"
+            android:layout_height="42dp"
+            android:layout_weight="1"
+            android:backgroundTint="#757575"
+            android:insetLeft="2dp"
+            android:insetRight="2dp"
+            android:text="@string/sync"
+            android:textColor="#fff" />
+
+        <TextView
+            android:id="@+id/rmBtn"
+            android:layout_width="35dp"
+            android:layout_height="34dp"
+            android:background="@drawable/rounded_corner"
+            android:clickable="true"
+            android:text="@string/remove"
+            android:textAlignment="center"
+            android:textColor="#fff"
+            android:textSize="24sp" />
+    </LinearLayout>
 
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/imageView"
@@ -207,16 +217,5 @@
             android:paddingTop="-10dp"
             android:paddingBottom="-10dp" />
     </androidx.cardview.widget.CardView>
-
-    <TextView
-        android:id="@+id/unsupported"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:gravity="center_vertical"
-        android:layout_marginRight="4dp"
-        android:text="不支持的格式"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/rmBtn" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
通过长按贴纸的删除按钮，触发删除缓存的功能。

允许在更新列表时忽略提示框，若需要删除多个贴纸时，可以改善用户体验。

添加了“只显示待同步表情包”功能。